### PR TITLE
URL-encode query parameter to Google

### DIFF
--- a/system/expressionengine/third_party/mx_google_map/mod.mx_google_map.php
+++ b/system/expressionengine/third_party/mx_google_map/mod.mx_google_map.php
@@ -398,7 +398,7 @@ class Mx_google_map {
 
     function GetLatLong( $query, $mode ) {
 
-        $query = str_replace( " ", "+", trim( $query ) );
+        $query = urlencode(trim($query));
         $xml_url = "http://maps.googleapis.com/maps/api/geocode/xml?address=".$query."&ie=utf-8&oe=utf-8&sensor=false";
 
         if ( !$out = $this->_readCache( md5( $query ) ) ) {


### PR DESCRIPTION
URL-encode the query that gets sent to Google so we can send any
user-entered data to Google without worrying whether it has invalid
characters.
