### PR TITLE
Allow developers to specify API Key in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,17 @@
 [Examples](http://www.demo-ee.com/examples/view/mx-google-map-hold-js)
 
 ![MX Google Map V1](images/mx-google-map-field__large.png)
+
+
+## Using An API Key
+
+If you use [Master Config][masterconfig], add the following to config.master.php:
+
+```
+$env_config['mx_google_map:api_key'] = 'YOUR_API_KEY';
+```
+
+`YOUR_API_KEY` can be retrieved at [https://code.google.com/apis/console](https://code.google.com/apis/console).
+
+
+[masterconfig]: https://github.com/focuslabllc/ee-master-config

--- a/system/expressionengine/third_party/mx_google_map/mod.mx_google_map.php
+++ b/system/expressionengine/third_party/mx_google_map/mod.mx_google_map.php
@@ -399,7 +399,12 @@ class Mx_google_map {
     function GetLatLong( $query, $mode ) {
 
         $query = str_replace( " ", "+", trim( $query ) );
-        $xml_url = "http://maps.googleapis.com/maps/api/geocode/xml?address=".$query."&ie=utf-8&oe=utf-8&sensor=false";
+        $xml_url = "https://maps.googleapis.com/maps/api/geocode/xml?address=".$query."&ie=utf-8&oe=utf-8&sensor=false";
+
+        $api_key = ee()->config->item('mx_google_map:api_key');
+        if ($api_key) {
+            $xml_url .= '&key=' . $api_key;
+        }
 
         if ( !$out = $this->_readCache( md5( $query ) ) ) {
             if ( ini_get( 'allow_url_fopen' ) ) {
@@ -408,6 +413,7 @@ class Mx_google_map {
                 $ch = curl_init( $xml_url );
                 curl_setopt( $ch, CURLOPT_HEADER, false );
                 curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
+                curl_setopt( $ch, CURLOPT_SSL_VERIFYPEER, false );
                 $xml_raw = curl_exec( $ch );
                 $xml     = simplexml_load_string( $xml_raw );
             }


### PR DESCRIPTION
Allow developers to specify an API key in the config. This prevents issues where API limits are being reached for requests without an API key, and helps separate sites that use the same host where their API limit would be shared because it's coming from the same IP address.

I don't have access to update http://www.eec.ms/user_guide/mx-google-map, so I added some documentation to the README.md on how to use this.
